### PR TITLE
Fixed bug in error handling

### DIFF
--- a/slncky.v1.0
+++ b/slncky.v1.0
@@ -120,7 +120,7 @@ def readAnnots(config_path, assembly):
 			print "WARNING: no genome fasta file was supplied in annotations.config for %s.  Cannot align to find duplications or matches to orthologous coding genes." %assembly
 		else:
 			if not os.path.isfile(ANNOTS['GENOME_FA'][0]+".fai"):
-				sys.exit("ERROR: fa index does not exist for %s. Please use samtools faidx to index .fa file."  % ANNOTS[GENOME_FA][0])
+				sys.exit("ERROR: fa index does not exist for %s. Please use samtools faidx to index .fa file."  % ANNOTS['GENOME_FA'][0])
 	
 	return ANNOTS
 


### PR DESCRIPTION
This fixes a small issue in error handling that causes a crash instead of providing the intended message, the program prints a stack trace and the following error:
"NameError: global name 'GENOME_FA' is not defined".